### PR TITLE
Chunked uploads, folder sync reliability, and mobile UX polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to Szurubooru Companion (CCC, browser extension, mobile app)
 
 ### Mobile App
 - Files larger than 50 MB now upload in chunks to avoid silent failures behind Cloudflare's 100 MB request limit; each chunk is retried up to 3 times on network error
+- Added "Upload only on WiFi" setting that pauses scheduled folder sync and offline-queue flushes while on cellular
+- Added a Quick Actions card at the top of Settings with one-tap Reconnect and Sync Now (previously buried under Folder Settings)
+- Fixed folder sync silently dying when the "Show persistent notification" toggle was turned off; the toggle has been removed since the foreground service always needs a notification
+- Added BOOT_COMPLETED receiver so scheduled folder sync alarms survive device reboots and app upgrades without needing to reopen the app
+- Folder sync alarm receiver now holds a short partial wake lock while enqueueing the WorkManager task, reducing the chance of the process being killed mid-handoff
+- Installed global error handlers (FlutterError.onError, PlatformDispatcher.onError, runZonedGuarded) so uncaught exceptions are logged instead of silently crashing the app
+- Fixed a stream subscription leak that accumulated dead listeners on each SSE reconnect
 
 ### Browser Extension
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to Szurubooru Companion (CCC, browser extension, mobile app)
 ### CCC - Frontend
 
 ### CCC - Backend
+- Add chunked upload endpoints (`POST /api/jobs/upload/init`, `/chunk/{id}/{n}`, `/complete/{id}`, `DELETE /upload/{id}`) so clients can split large files into 10 MB parts and bypass edge-proxy per-request size limits (e.g. Cloudflare's 100 MB cap)
 
 ### Mobile App
+- Files larger than 50 MB now upload in chunks to avoid silent failures behind Cloudflare's 100 MB request limit; each chunk is retried up to 3 times on network error
 
 ### Browser Extension
 

--- a/ccc/backend/app/api/jobs_upload_chunked.py
+++ b/ccc/backend/app/api/jobs_upload_chunked.py
@@ -1,0 +1,184 @@
+"""
+Chunked file-upload endpoints for large files.
+
+The single-POST /api/jobs/upload endpoint in jobs.py works fine for smaller
+files, but uploads over ~100 MB hit Cloudflare's per-request body limit. This
+module adds a three-step flow so clients can split large files into chunks:
+
+    1. POST /api/jobs/upload/init             -> session_id, chunk_size, total_chunks
+    2. POST /api/jobs/upload/chunk/{id}/{n}   -> append chunk (n = 0..N-1)
+    3. POST /api/jobs/upload/complete/{id}    -> reassemble + create Job
+
+Chunk uploads are idempotent (re-sending chunk N overwrites) so clients can
+safely retry individual chunks on network failure. Sessions expire after 24h.
+"""
+
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.api.jobs import JobOut, _job_to_out, _parse_json_tags, _safe_upload_filename
+from app.config import get_settings
+from app.database import Job, JobType, User, get_db
+from app.services import upload_sessions
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+router = APIRouter()
+
+MAX_FILENAME_LEN = 512
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024 * 1024  # 10 GB sanity cap
+
+
+class UploadInitRequest(BaseModel):
+    filename: str = Field(..., min_length=1, max_length=MAX_FILENAME_LEN)
+    total_size: int = Field(..., gt=0, le=MAX_UPLOAD_BYTES)
+    safety: str = "unsafe"
+    skip_tagging: bool = False
+    tags: Optional[str] = None
+    source: Optional[str] = None
+
+
+class UploadInitResponse(BaseModel):
+    session_id: str
+    chunk_size: int
+    total_chunks: int
+    expires_at: datetime
+
+
+class UploadChunkResponse(BaseModel):
+    received_chunks: int
+    total_chunks: int
+
+
+def _session_user_id(user: User) -> str:
+    return str(user.id) if user.id is not None else "api_key"
+
+
+async def _load_owned_session(session_id: str, user: User) -> upload_sessions.UploadSession:
+    """Fetch session and verify ownership; raise 404 otherwise (hides existence)."""
+    session = await upload_sessions.get_session(session_id)
+    if not session or session.user_id != _session_user_id(user):
+        raise HTTPException(status_code=404, detail="Upload session not found.")
+    return session
+
+
+@router.post("/jobs/upload/init", response_model=UploadInitResponse, status_code=201)
+async def init_upload(
+    body: UploadInitRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Start a chunked upload session. Returns the chunk size and count to use."""
+    safe_filename = _safe_upload_filename(body.filename)
+    session = await upload_sessions.create_session(
+        user_id=_session_user_id(current_user),
+        filename=safe_filename,
+        total_size=body.total_size,
+        safety=body.safety or "unsafe",
+        skip_tagging=body.skip_tagging,
+        tags=body.tags,
+        source=body.source,
+    )
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=upload_sessions.SESSION_TTL_SECONDS)
+    return UploadInitResponse(
+        session_id=session.id,
+        chunk_size=session.chunk_size,
+        total_chunks=session.total_chunks,
+        expires_at=expires_at,
+    )
+
+
+@router.post(
+    "/jobs/upload/chunk/{session_id}/{chunk_number}",
+    response_model=UploadChunkResponse,
+)
+async def upload_chunk(
+    session_id: str,
+    chunk_number: int,
+    chunk: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+):
+    """Upload a single chunk. Idempotent: re-sending the same chunk number overwrites."""
+    session = await _load_owned_session(session_id, current_user)
+
+    if chunk_number < 0 or chunk_number >= session.total_chunks:
+        raise HTTPException(status_code=400, detail="Chunk number out of range.")
+
+    received = await upload_sessions.store_chunk(session, chunk_number, chunk.file)
+    return UploadChunkResponse(received_chunks=received, total_chunks=session.total_chunks)
+
+
+@router.post("/jobs/upload/complete/{session_id}", response_model=JobOut, status_code=201)
+async def complete_upload(
+    session_id: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Reassemble chunks, create a Job, and clean up the session."""
+    session = await _load_owned_session(session_id, current_user)
+
+    received = await upload_sessions.received_chunks(session_id)
+    if len(received) != session.total_chunks:
+        missing = sorted(set(range(session.total_chunks)) - set(received))
+        first_missing = missing[0] if missing else None
+        raise HTTPException(
+            status_code=400,
+            detail=f"Upload incomplete: missing {len(missing)} chunk(s) (first missing: {first_missing}).",
+        )
+
+    job_id = uuid.uuid4()
+    job_dir = os.path.join(settings.job_data_dir, str(job_id))
+    dest = os.path.join(job_dir, session.filename)
+
+    try:
+        await upload_sessions.assemble(session, dest)
+    except (FileNotFoundError, ValueError) as e:
+        # Leave the session intact so the client can retry missing chunks.
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    parsed_tags = _parse_json_tags(session.tags) if session.tags else None
+    if parsed_tags is None and session.tags:
+        parsed_tags = [t.strip() for t in session.tags.split(",") if t.strip()]
+
+    job = Job(
+        id=job_id,
+        job_type=JobType.FILE,
+        original_filename=session.filename,
+        source_override=session.source,
+        initial_tags=json.dumps(parsed_tags) if parsed_tags else None,
+        safety=session.safety,
+        skip_tagging=1 if session.skip_tagging else 0,
+        szuru_user=current_user.szuru_username,
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+
+    await upload_sessions.delete_session(session_id)
+
+    from app.api.events import publish_job_update
+    await publish_job_update(job_id=job.id, status="pending", progress=0)
+    return _job_to_out(job)
+
+
+@router.delete("/jobs/upload/{session_id}", status_code=200)
+async def abort_upload(
+    session_id: str,
+    current_user: User = Depends(get_current_user),
+):
+    """Abort and clean up an in-progress chunked upload session."""
+    session = await upload_sessions.get_session(session_id)
+    if not session:
+        return {"deleted": False}
+    if session.user_id != _session_user_id(current_user):
+        raise HTTPException(status_code=404, detail="Upload session not found.")
+    await upload_sessions.delete_session(session_id)
+    return {"deleted": True}

--- a/ccc/backend/app/main.py
+++ b/ccc/backend/app/main.py
@@ -18,6 +18,7 @@ from app.config import get_settings
 from app.database import init_db
 from app.migrations import run_migrations
 from app.api.jobs import router as jobs_router
+from app.api.jobs_upload_chunked import router as jobs_upload_chunked_router
 from app.api.stats import router as stats_router
 from app.api.health import router as health_router
 from app.api.events import router as events_router
@@ -34,6 +35,7 @@ from app.services.szurubooru import (
     close_session as close_szuru_session,
     load_tag_cache,
 )
+from app.services.upload_sessions import cleanup_loop as upload_sessions_cleanup_loop
 from app.workers.processor import start_worker, stop_worker
 
 settings = get_settings()
@@ -75,13 +77,16 @@ async def lifespan(app: FastAPI):
     logger.info("Starting %d background worker(s) (WORKER_CONCURRENCY)...", num_workers)
     worker_tasks = [asyncio.create_task(start_worker(i)) for i in range(num_workers)]
 
+    upload_cleanup_task = asyncio.create_task(upload_sessions_cleanup_loop())
+
     yield
 
     logger.info("Shutting down workers...")
     await stop_worker()
+    upload_cleanup_task.cancel()
     for task in worker_tasks:
         task.cancel()
-    await asyncio.gather(*worker_tasks, return_exceptions=True)
+    await asyncio.gather(*worker_tasks, upload_cleanup_task, return_exceptions=True)
 
     logger.info("Closing Szurubooru session...")
     await close_szuru_session()
@@ -164,6 +169,7 @@ app.include_router(users_router, prefix="/api", tags=["users"])
 app.include_router(settings_router, prefix="/api", tags=["settings"])
 app.include_router(preferences_router, prefix="/api", tags=["preferences"])
 app.include_router(jobs_router, prefix="/api", tags=["jobs"])
+app.include_router(jobs_upload_chunked_router, prefix="/api", tags=["jobs"])
 app.include_router(stats_router, prefix="/api", tags=["stats"])
 app.include_router(events_router, prefix="/api", tags=["events"])
 app.include_router(config_router, prefix="/api", tags=["config"])

--- a/ccc/backend/app/services/upload_sessions.py
+++ b/ccc/backend/app/services/upload_sessions.py
@@ -1,0 +1,238 @@
+"""
+Chunked upload session management.
+
+Sessions live in Redis (TTL 24h) with chunk files on disk under
+``{job_data_dir}/upload_sessions/{session_id}/``. When all chunks are
+received, the session is finalized by the /complete endpoint: chunks are
+reassembled into the job data directory, a Job row is created, and the
+session is cleaned up.
+"""
+
+import asyncio
+import logging
+import os
+import shutil
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from redis.asyncio import Redis
+
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+# Server-dictated chunk size. 10 MB keeps each request well below common
+# edge-proxy body limits (Cloudflare free tier caps at 100 MB per request).
+CHUNK_SIZE_BYTES = 10 * 1024 * 1024
+SESSION_TTL_SECONDS = 24 * 60 * 60
+SESSIONS_SUBDIR = "upload_sessions"
+
+
+def _session_key(session_id: str) -> str:
+    return f"upload_session:{session_id}"
+
+
+def _received_key(session_id: str) -> str:
+    return f"upload_session:{session_id}:received"
+
+
+def _session_dir(session_id: str) -> str:
+    return os.path.join(settings.job_data_dir, SESSIONS_SUBDIR, session_id)
+
+
+def _chunk_path(session_id: str, chunk_number: int) -> str:
+    return os.path.join(_session_dir(session_id), f"chunk_{chunk_number}.part")
+
+
+def _redis() -> Redis:
+    return Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+@dataclass
+class UploadSession:
+    id: str
+    user_id: str
+    filename: str
+    total_size: int
+    total_chunks: int
+    chunk_size: int
+    safety: str
+    skip_tagging: bool
+    tags: Optional[str]
+    source: Optional[str]
+
+
+async def create_session(
+    user_id: str,
+    filename: str,
+    total_size: int,
+    safety: str,
+    skip_tagging: bool,
+    tags: Optional[str],
+    source: Optional[str],
+) -> UploadSession:
+    """Create a new upload session and its on-disk chunk dir."""
+    session_id = str(uuid.uuid4())
+    total_chunks = max(1, (total_size + CHUNK_SIZE_BYTES - 1) // CHUNK_SIZE_BYTES)
+
+    os.makedirs(_session_dir(session_id), exist_ok=True)
+
+    data = {
+        "user_id": user_id,
+        "filename": filename,
+        "total_size": str(total_size),
+        "total_chunks": str(total_chunks),
+        "chunk_size": str(CHUNK_SIZE_BYTES),
+        "safety": safety,
+        "skip_tagging": "1" if skip_tagging else "0",
+        "tags": tags or "",
+        "source": source or "",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    redis = _redis()
+    try:
+        await redis.hset(_session_key(session_id), mapping=data)
+        await redis.expire(_session_key(session_id), SESSION_TTL_SECONDS)
+    finally:
+        await redis.close()
+
+    return UploadSession(
+        id=session_id,
+        user_id=user_id,
+        filename=filename,
+        total_size=total_size,
+        total_chunks=total_chunks,
+        chunk_size=CHUNK_SIZE_BYTES,
+        safety=safety,
+        skip_tagging=skip_tagging,
+        tags=tags,
+        source=source,
+    )
+
+
+async def get_session(session_id: str) -> Optional[UploadSession]:
+    """Load a session from Redis, or return None if missing/expired."""
+    redis = _redis()
+    try:
+        data = await redis.hgetall(_session_key(session_id))
+    finally:
+        await redis.close()
+    if not data:
+        return None
+    try:
+        return UploadSession(
+            id=session_id,
+            user_id=data["user_id"],
+            filename=data["filename"],
+            total_size=int(data["total_size"]),
+            total_chunks=int(data["total_chunks"]),
+            chunk_size=int(data["chunk_size"]),
+            safety=data.get("safety") or "unsafe",
+            skip_tagging=data.get("skip_tagging") == "1",
+            tags=data.get("tags") or None,
+            source=data.get("source") or None,
+        )
+    except (KeyError, ValueError):
+        return None
+
+
+async def store_chunk(session: UploadSession, chunk_number: int, stream) -> int:
+    """Write a chunk atomically to disk and record receipt; returns received count."""
+    os.makedirs(_session_dir(session.id), exist_ok=True)
+    path = _chunk_path(session.id, chunk_number)
+    tmp_path = path + ".tmp"
+    with open(tmp_path, "wb") as f:
+        shutil.copyfileobj(stream, f)
+    os.replace(tmp_path, path)
+
+    redis = _redis()
+    try:
+        await redis.sadd(_received_key(session.id), chunk_number)
+        await redis.expire(_received_key(session.id), SESSION_TTL_SECONDS)
+        await redis.expire(_session_key(session.id), SESSION_TTL_SECONDS)
+        return await redis.scard(_received_key(session.id))
+    finally:
+        await redis.close()
+
+
+async def received_chunks(session_id: str) -> List[int]:
+    redis = _redis()
+    try:
+        members = await redis.smembers(_received_key(session_id))
+    finally:
+        await redis.close()
+    try:
+        return sorted(int(m) for m in members)
+    except ValueError:
+        return []
+
+
+async def assemble(session: UploadSession, dest_path: str) -> None:
+    """Reassemble chunks into dest_path. Raises if a chunk is missing or size mismatches."""
+    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+    with open(dest_path, "wb") as out:
+        for i in range(session.total_chunks):
+            part = _chunk_path(session.id, i)
+            if not os.path.isfile(part):
+                raise FileNotFoundError(f"Missing chunk {i} for session {session.id}")
+            with open(part, "rb") as src:
+                shutil.copyfileobj(src, out)
+
+    size = os.path.getsize(dest_path)
+    if size != session.total_size:
+        raise ValueError(
+            f"Assembled size {size} does not match expected {session.total_size}"
+        )
+
+
+async def delete_session(session_id: str) -> None:
+    """Remove Redis keys and on-disk chunks for a session."""
+    redis = _redis()
+    try:
+        await redis.delete(_session_key(session_id), _received_key(session_id))
+    finally:
+        await redis.close()
+
+    session_dir = _session_dir(session_id)
+    if os.path.isdir(session_dir):
+        shutil.rmtree(session_dir, ignore_errors=True)
+
+
+async def _cleanup_orphaned_dirs() -> None:
+    """Delete chunk dirs whose Redis session no longer exists (TTL-expired or aborted)."""
+    base = os.path.join(settings.job_data_dir, SESSIONS_SUBDIR)
+    if not os.path.isdir(base):
+        return
+    try:
+        entries = os.listdir(base)
+    except OSError:
+        return
+
+    redis = _redis()
+    try:
+        for name in entries:
+            path = os.path.join(base, name)
+            if not os.path.isdir(path):
+                continue
+            exists = await redis.exists(_session_key(name))
+            if not exists:
+                shutil.rmtree(path, ignore_errors=True)
+                logger.info("Cleaned up orphaned upload session dir: %s", name)
+    finally:
+        await redis.close()
+
+
+async def cleanup_loop(interval_seconds: int = 3600) -> None:
+    """Background task: periodically removes orphaned chunk dirs."""
+    while True:
+        try:
+            await _cleanup_orphaned_dirs()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("Upload session cleanup error: %s", e)
+        await asyncio.sleep(interval_seconds)

--- a/mobile-app/android/app/src/main/AndroidManifest.xml
+++ b/mobile-app/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 
     <!-- Exact alarm permissions for reliable background sync (Android 12+) -->
@@ -114,6 +115,17 @@
             android:exported="false">
             <intent-filter>
                 <action android:name="com.szurubooru.szuruqueue.FOLDER_SYNC"/>
+            </intent-filter>
+        </receiver>
+
+        <!-- Re-register folder sync alarms and start foreground service after device reboot -->
+        <receiver
+            android:name=".BootReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
             </intent-filter>
         </receiver>
 

--- a/mobile-app/android/app/src/main/kotlin/com/szurubooru/szuruqueue/BootReceiver.kt
+++ b/mobile-app/android/app/src/main/kotlin/com/szurubooru/szuruqueue/BootReceiver.kt
@@ -1,0 +1,76 @@
+package com.szurubooru.szuruqueue
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+
+/**
+ * Re-registers the folder sync alarm after a device reboot or app upgrade.
+ * AlarmManager alarms do not persist across reboots, so without this the
+ * scheduled folder sync silently stops firing until the user opens the app
+ * and saves settings again.
+ */
+class BootReceiver : BroadcastReceiver() {
+    companion object {
+        private const val TAG = "BootReceiver"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED &&
+            intent.action != Intent.ACTION_MY_PACKAGE_REPLACED) {
+            return
+        }
+
+        Log.i(TAG, "Received ${intent.action}, re-registering folder sync alarm")
+
+        val prefs = context.getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
+        val intervalSeconds = prefs.getLong("flutter.folderSyncIntervalSeconds", 900L).toInt()
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
+            Log.w(TAG, "Cannot schedule exact alarms after boot; user must re-grant permission")
+            return
+        }
+
+        val alarmIntent = Intent(context, FolderSyncAlarmReceiver::class.java).apply {
+            action = FolderSyncAlarmReceiver.ACTION_FOLDER_SYNC
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            0,
+            alarmIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val now = System.currentTimeMillis()
+        val intervalMillis = (intervalSeconds * 1000L).coerceIn(900000L, 604800000L)
+        val intervalMinutes = (intervalMillis / 60000).toInt()
+        val nowMinutes = (now / 60000) % 1440
+        val nextSlotMinutes = ((nowMinutes / intervalMinutes) + 1) * intervalMinutes
+        val minutesToNext = nextSlotMinutes - nowMinutes
+        val nextSyncTime = now + (minutesToNext * 60000)
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    nextSyncTime,
+                    pendingIntent
+                )
+            } else {
+                alarmManager.setExact(
+                    AlarmManager.RTC_WAKEUP,
+                    nextSyncTime,
+                    pendingIntent
+                )
+            }
+            Log.i(TAG, "Alarm re-registered for ${java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US).format(java.util.Date(nextSyncTime))}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to re-register alarm after boot", e)
+        }
+    }
+}

--- a/mobile-app/android/app/src/main/kotlin/com/szurubooru/szuruqueue/FolderSyncAlarmReceiver.kt
+++ b/mobile-app/android/app/src/main/kotlin/com/szurubooru/szuruqueue/FolderSyncAlarmReceiver.kt
@@ -6,6 +6,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.PowerManager
 import android.util.Log
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
@@ -41,6 +42,14 @@ class FolderSyncAlarmReceiver : BroadcastReceiver() {
         Log.d(TAG, "Date: ${java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.US).format(java.util.Date())}")
         Log.d(TAG, "======================================")
 
+        // Hold a short partial wake lock so the WorkManager enqueue completes
+        // before the device can re-enter Doze. Released after the WM task is
+        // scheduled; the enqueued task runs under WorkManager's own wake lock.
+        val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        val wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "SzuruCompanion:FolderSyncAlarm")
+        wakeLock.setReferenceCounted(false)
+        wakeLock.acquire(30_000L)
+
         // IMPORTANT: Reschedule the next alarm BEFORE running the task
         // This ensures periodic execution continues even if the task fails
         rescheduleNextAlarm(context)
@@ -75,6 +84,12 @@ class FolderSyncAlarmReceiver : BroadcastReceiver() {
             Log.d(TAG, "Task: folder_scan_task, will call callbackDispatcher() in Dart")
         } catch (e: Exception) {
             Log.e(TAG, "Error enqueueing work: ${e.message}", e)
+        } finally {
+            try {
+                if (wakeLock.isHeld) wakeLock.release()
+            } catch (e: Exception) {
+                Log.w(TAG, "Error releasing wake lock", e)
+            }
         }
     }
 

--- a/mobile-app/lib/main.dart
+++ b/mobile-app/lib/main.dart
@@ -1,3 +1,7 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_phoenix/flutter_phoenix.dart';
 import 'package:provider/provider.dart';
@@ -18,22 +22,42 @@ import 'src/utils/markdown_plain_text.dart';
 import 'src/widgets/app_lock_gate.dart';
 
 void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await NotificationService.instance.init(
-    onNotificationResponse: (response) {
-      final payload = response.payload;
-      if (payload == 'update_available' || payload == 'ready_to_install') {
-        UpdateService.getInstance().then((s) => s.handleNotificationTap(payload));
-      }
-    },
-  );
-  await initializeBackgroundTasks();
+  // Install global error handlers BEFORE anything else so startup failures and
+  // uncaught async errors are captured rather than dying silently.
+  FlutterError.onError = (details) {
+    FlutterError.presentError(details);
+    debugPrint('[UncaughtFlutterError] ${details.exceptionAsString()}');
+    if (details.stack != null) {
+      debugPrint('[UncaughtFlutterError] ${details.stack}');
+    }
+  };
+  PlatformDispatcher.instance.onError = (error, stack) {
+    debugPrint('[UncaughtPlatformError] $error');
+    debugPrint('[UncaughtPlatformError] $stack');
+    return true;
+  };
 
-  runApp(
-    Phoenix(
-      child: const _AppRoot(),
-    ),
-  );
+  await runZonedGuarded<Future<void>>(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    await NotificationService.instance.init(
+      onNotificationResponse: (response) {
+        final payload = response.payload;
+        if (payload == 'update_available' || payload == 'ready_to_install') {
+          UpdateService.getInstance().then((s) => s.handleNotificationTap(payload));
+        }
+      },
+    );
+    await initializeBackgroundTasks();
+
+    runApp(
+      Phoenix(
+        child: const _AppRoot(),
+      ),
+    );
+  }, (error, stack) {
+    debugPrint('[UncaughtZoneError] $error');
+    debugPrint('[UncaughtZoneError] $stack');
+  });
 }
 
 /// Loads settings and builds the provider tree. Rebuilt on Phoenix.rebirth() so

--- a/mobile-app/lib/src/screens/main_screen.dart
+++ b/mobile-app/lib/src/screens/main_screen.dart
@@ -103,15 +103,13 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       final folders = await settings.getScheduledFolders();
       if (!mounted) return;
       final hasFoldersEnabled = folders.any((f) => f.enabled == true);
-      final folderSyncEnabled =
-          hasFoldersEnabled && settings.showPersistentNotification;
-      if (folderSyncEnabled) {
+      if (hasFoldersEnabled) {
         await startCompanionForegroundService(
           folderSyncEnabled: true,
-          bubbleEnabled: settings.showFloatingBubble && folderSyncEnabled,
+          bubbleEnabled: settings.showFloatingBubble,
           statusBody: buildCompanionNotificationBody(
             folderSyncOn: true,
-            bubbleOn: settings.showFloatingBubble && folderSyncEnabled,
+            bubbleOn: settings.showFloatingBubble,
           ),
         );
         if (!mounted) return;
@@ -208,8 +206,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
       if (!settings.isConfigured || !settings.isAuthenticated) return;
       
       final folders = await settings.getScheduledFolders();
-      final folderSyncOn = folders.where((f) => f.enabled).isNotEmpty &&
-          settings.showPersistentNotification;
+      final folderSyncOn = folders.where((f) => f.enabled).isNotEmpty;
       if (!folderSyncOn && !settings.showFloatingBubble) return;
       if (!mounted) return;
       final connectionText = appState.isConnected
@@ -357,11 +354,6 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
             _lastNotificationUpdate = DateTime.now();
             await _updateStatusNotificationIfNeeded(settings, appState);
             if (!mounted) return;
-            if (!settings.showPersistentNotification) {
-              _statusNotificationReshowTimer?.cancel();
-              _statusNotificationReshowTimer = null;
-              return;
-            }
             final folders = await settings.getScheduledFolders();
             if (!mounted) return;
             if (folders.any((f) => f.enabled == true)) {

--- a/mobile-app/lib/src/screens/settings_screen.dart
+++ b/mobile-app/lib/src/screens/settings_screen.dart
@@ -25,6 +25,7 @@ import '../widgets/settings/app_lock_card.dart';
 import '../widgets/settings/backup_restore_card.dart';
 import '../widgets/settings/backend_settings_card.dart';
 import '../widgets/settings/folder_settings_card.dart';
+import '../widgets/settings/quick_actions_card.dart';
 import '../widgets/settings/share_settings_card.dart';
 
 /// Settings screen for the Szuru Companion app
@@ -49,6 +50,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   bool _deleteMediaAfterSync = false;
   bool _showPersistentNotification = true;
   bool _showFloatingBubble = false;
+  bool _uploadOnlyOnWifi = false;
   int _folderSyncIntervalSeconds = 900;
   bool _isSyncingFolders = false;
   bool _isRestoreInProgress = false;
@@ -106,6 +108,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _deleteMediaAfterSync = settings.deleteMediaAfterSync;
       _showPersistentNotification = settings.showPersistentNotification;
       _showFloatingBubble = settings.showFloatingBubble;
+      _uploadOnlyOnWifi = settings.uploadOnlyOnWifi;
       _folderSyncIntervalSeconds = settings.folderSyncIntervalSeconds;
     });
   }
@@ -207,8 +210,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               if (granted) {
                 setState(() { _showFloatingBubble = true; });
                 _showSnackBar('Overlay permission granted - floating bubble enabled');
-                final folderSyncEnabledNow = hasFoldersEnabled && _showPersistentNotification;
-                if (folderSyncEnabledNow) {
+                if (hasFoldersEnabled) {
                   await startCompanionForegroundService(
                     folderSyncEnabled: true,
                     bubbleEnabled: true,
@@ -246,6 +248,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         deleteMediaAfterSync: _deleteMediaAfterSync,
         showPersistentNotification: _showPersistentNotification,
         showFloatingBubble: _showFloatingBubble,
+        uploadOnlyOnWifi: _uploadOnlyOnWifi,
         folderSyncIntervalSeconds: _folderSyncIntervalSeconds,
       );
       if (!mounted) return;
@@ -268,14 +271,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
         }
       }
 
-      final folderSyncEnabled = hasFoldersEnabled && _showPersistentNotification;
-      if (folderSyncEnabled) {
+      // Folder sync no longer depends on _showPersistentNotification — Android
+      // requires a notification for foreground services anyway, and without
+      // the foreground service the process gets killed and folder sync dies.
+      if (hasFoldersEnabled) {
         await startCompanionForegroundService(
           folderSyncEnabled: true,
-          bubbleEnabled: _showFloatingBubble && folderSyncEnabled,
+          bubbleEnabled: _showFloatingBubble,
           statusBody: buildCompanionNotificationBody(
             folderSyncOn: true,
-            bubbleOn: _showFloatingBubble && folderSyncEnabled,
+            bubbleOn: _showFloatingBubble,
           ),
         );
         if (!mounted) return;
@@ -352,8 +357,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final folders = await settings.getScheduledFolders();
     if (!mounted) return;
     final hasFoldersEnabled = folders.any((f) => f.enabled == true);
-    final folderSyncEnabled = hasFoldersEnabled && _showPersistentNotification;
-    if (folderSyncEnabled) {
+    if (hasFoldersEnabled) {
       await startCompanionForegroundService(
         folderSyncEnabled: true,
         bubbleEnabled: true,
@@ -561,6 +565,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            QuickActionsCard(
+              isSyncingFolders: _isSyncingFolders,
+              onSyncNow: _runFolderSync,
+            ),
             BackendSettingsCard(
               backendUrlController: _backendUrlController,
               backendUrlFocusNode: _backendUrlFocusNode,
@@ -580,12 +588,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
               isSyncingFolders: _isSyncingFolders,
               notifyOnFolderSync: _notifyOnFolderSync,
               deleteMediaAfterSync: _deleteMediaAfterSync,
-              showPersistentNotification: _showPersistentNotification,
+              uploadOnlyOnWifi: _uploadOnlyOnWifi,
               folderSyncIntervalSeconds: _folderSyncIntervalSeconds,
               onSyncNow: _runFolderSync,
               onNotifyOnFolderSyncChanged: (value) => setState(() => _notifyOnFolderSync = value),
               onDeleteMediaAfterSyncChanged: (value) => setState(() => _deleteMediaAfterSync = value),
-              onShowPersistentNotificationChanged: (value) => setState(() => _showPersistentNotification = value),
+              onUploadOnlyOnWifiChanged: (value) => setState(() => _uploadOnlyOnWifi = value),
               onFolderSyncIntervalChanged: (value) => setState(() => _folderSyncIntervalSeconds = value),
               onAutoSave: () => _autoSaveSettings(validate: false),
             ),

--- a/mobile-app/lib/src/services/app_state.dart
+++ b/mobile-app/lib/src/services/app_state.dart
@@ -31,6 +31,7 @@ class AppState extends ChangeNotifier {
   BackendClient? _backendClient;
   StreamSubscription<SseConnectionState>? _sseStateSubscription;
   StreamSubscription<JobUpdate>? _jobUpdateSubscription;
+  StreamSubscription<SseEvent>? _sseRawSubscription;
   
   // Track previous URL to avoid unnecessary SSE reconnections
   String _previousBackendUrl = '';
@@ -114,8 +115,9 @@ class AppState extends ChangeNotifier {
       _handleJobUpdate(update);
     });
     
-    // Also listen to the raw stream for errors
-    sseStream.listen(
+    // Also listen to the raw stream for connection/error signals.
+    // Track the subscription so reconnects don't leak listeners onto dead controllers.
+    _sseRawSubscription = sseStream.listen(
       (event) {
         // Events are handled via jobUpdateStream
         if (event.type == SseEventType.connected) {
@@ -143,6 +145,8 @@ class AppState extends ChangeNotifier {
     _sseStateSubscription = null;
     _jobUpdateSubscription?.cancel();
     _jobUpdateSubscription = null;
+    _sseRawSubscription?.cancel();
+    _sseRawSubscription = null;
     _backendClient?.disconnectSse();
     sseConnectionState = SseConnectionState.disconnected;
   }

--- a/mobile-app/lib/src/services/backend_client.dart
+++ b/mobile-app/lib/src/services/backend_client.dart
@@ -151,6 +151,10 @@ enum SseConnectionState {
 /// - SSE streaming for real-time updates
 /// - JWT Bearer token authentication
 class BackendClient {
+  // Files larger than this use the chunked upload flow to stay below edge-proxy
+  // per-request body limits (Cloudflare free tier caps at 100 MB).
+  static const int _chunkedUploadThresholdBytes = 50 * 1024 * 1024;
+
   final Dio _dio;
   final String baseUrl;
   String? _accessToken;
@@ -602,9 +606,11 @@ class BackendClient {
   }
 
   /// Upload a file to the backend for processing.
-  /// 
-  /// Backend endpoint: POST /api/jobs/upload
-  /// Uses multipart form data to upload the file.
+  ///
+  /// Backend endpoint: POST /api/jobs/upload (single-POST)
+  /// or /api/jobs/upload/{init,chunk,complete} (chunked, for large files).
+  /// Files above [_chunkedUploadThresholdBytes] are uploaded in chunks to
+  /// bypass edge-proxy per-request body limits.
   /// Returns (jobId, null) on success, (null, errorMessage) on failure.
   Future<({String? jobId, String? error})> enqueueFromFile({
     required File file,
@@ -613,6 +619,22 @@ class BackendClient {
     String? safety,
     bool? skipTagging,
   }) async {
+    int fileSize;
+    try {
+      fileSize = await file.length();
+    } catch (e) {
+      return (jobId: null, error: 'Could not read file: $e');
+    }
+    if (fileSize > _chunkedUploadThresholdBytes) {
+      return _enqueueFromFileChunked(
+        file: file,
+        fileSize: fileSize,
+        source: source,
+        tags: tags,
+        safety: safety,
+        skipTagging: skipTagging,
+      );
+    }
     final uri = Uri.parse('$baseUrl/api/jobs/upload');
     final request = http.MultipartRequest('POST', uri);
     if (_accessToken != null && _accessToken!.isNotEmpty) {
@@ -717,6 +739,121 @@ class BackendClient {
       debugPrint('[BackendClient] Exception during upload: $e');
       debugPrint('[BackendClient] Stack trace: $stackTrace');
       return (jobId: null, error: e.toString());
+    }
+  }
+
+  /// Upload a large file via the chunked upload API.
+  ///
+  /// Flow: init (reserve session) -> N chunk POSTs -> complete (reassemble +
+  /// create job). Each chunk is retried up to 3 times with exponential backoff.
+  /// On unrecoverable error, best-effort aborts the server session to release
+  /// disk space early (the server also TTL-cleans after 24h).
+  Future<({String? jobId, String? error})> _enqueueFromFileChunked({
+    required File file,
+    required int fileSize,
+    String? source,
+    List<String>? tags,
+    String? safety,
+    bool? skipTagging,
+  }) async {
+    String? sessionId;
+    try {
+      final initPayload = <String, dynamic>{
+        'filename': _basenameFromPath(file.path),
+        'total_size': fileSize,
+      };
+      if (safety != null && safety.isNotEmpty) initPayload['safety'] = safety;
+      if (skipTagging != null) initPayload['skip_tagging'] = skipTagging;
+      if (tags != null && tags.isNotEmpty) initPayload['tags'] = tags.join(',');
+      if (source != null && source.isNotEmpty) initPayload['source'] = source;
+
+      debugPrint('[BackendClient] Chunked upload: init for ${initPayload['filename']} ($fileSize bytes)');
+      final initResp = await _dio.post('/api/jobs/upload/init', data: initPayload);
+      final initData = initResp.data as Map<String, dynamic>;
+      sessionId = initData['session_id'] as String;
+      final chunkSize = initData['chunk_size'] as int;
+      final totalChunks = initData['total_chunks'] as int;
+      debugPrint('[BackendClient] Chunked upload: session=$sessionId chunkSize=$chunkSize totalChunks=$totalChunks');
+
+      final raf = await file.open();
+      try {
+        for (int i = 0; i < totalChunks; i++) {
+          final offset = i * chunkSize;
+          final length = (offset + chunkSize <= fileSize)
+              ? chunkSize
+              : (fileSize - offset);
+          await raf.setPosition(offset);
+          final bytes = await raf.read(length);
+
+          Object? lastError;
+          bool sent = false;
+          for (int attempt = 0; attempt < 3 && !sent; attempt++) {
+            try {
+              final form = FormData.fromMap({
+                'chunk': MultipartFile.fromBytes(bytes, filename: 'chunk_$i'),
+              });
+              await _dio.post(
+                '/api/jobs/upload/chunk/$sessionId/$i',
+                data: form,
+                options: Options(
+                  sendTimeout: const Duration(minutes: 2),
+                  receiveTimeout: const Duration(minutes: 2),
+                ),
+              );
+              sent = true;
+            } catch (e) {
+              lastError = e;
+              if (attempt < 2) {
+                await Future.delayed(Duration(seconds: 1 << attempt));
+              }
+            }
+          }
+          if (!sent) {
+            debugPrint('[BackendClient] Chunk $i failed after 3 attempts: $lastError');
+            await _abortChunkedUpload(sessionId);
+            sessionId = null;
+            return (
+              jobId: null,
+              error: 'Upload failed on chunk ${i + 1} of $totalChunks: $lastError',
+            );
+          }
+        }
+      } finally {
+        await raf.close();
+      }
+
+      final completeResp = await _dio.post(
+        '/api/jobs/upload/complete/$sessionId',
+        options: Options(receiveTimeout: const Duration(minutes: 5)),
+      );
+      final jobId = (completeResp.data as Map<String, dynamic>)['id']?.toString();
+      debugPrint('[BackendClient] Chunked upload complete, jobId: $jobId');
+      sessionId = null;
+      return (jobId: jobId, error: null);
+    } on DioException catch (e) {
+      if (sessionId != null) {
+        await _abortChunkedUpload(sessionId);
+      }
+      final code = e.response?.statusCode;
+      final message = code == 401
+          ? 'Session expired. Please log in again.'
+          : (_messageFromDioException(e) ?? _friendlyLabelForStatusCode(code));
+      return (jobId: null, error: message);
+    } catch (e, stackTrace) {
+      debugPrint('[BackendClient] Chunked upload exception: $e');
+      debugPrint('[BackendClient] Stack trace: $stackTrace');
+      if (sessionId != null) {
+        await _abortChunkedUpload(sessionId);
+      }
+      return (jobId: null, error: e.toString());
+    }
+  }
+
+  Future<void> _abortChunkedUpload(String sessionId) async {
+    try {
+      await _dio.delete('/api/jobs/upload/$sessionId');
+    } catch (_) {
+      // Server will clean up on TTL; best-effort only.
     }
   }
 
@@ -1051,6 +1188,13 @@ class BackendException implements Exception {
 
   @override
   String toString() => 'BackendException: $message${statusCode != null ? ' (status: $statusCode)' : ''}';
+}
+
+/// Strip any directory component from a file path (handles both / and \).
+String _basenameFromPath(String path) {
+  final normalized = path.replaceAll('\\', '/');
+  final idx = normalized.lastIndexOf('/');
+  return idx >= 0 ? normalized.substring(idx + 1) : normalized;
 }
 
 /// Extracts backend error message from DioException response body (e.g. FastAPI detail).

--- a/mobile-app/lib/src/services/background_task.dart
+++ b/mobile-app/lib/src/services/background_task.dart
@@ -9,6 +9,7 @@ import 'folder_scanner.dart';
 import '../models/auth.dart';
 import '../models/scheduled_folder.dart';
 import 'companion_foreground_service.dart';
+import 'network_gate.dart';
 import 'notification_service.dart';
 import 'settings_model.dart';
 import 'update_service.dart';
@@ -168,21 +169,20 @@ void callbackDispatcher() {
         '[BackgroundIsolate] Folder scan complete: uploaded=${outcome.uploaded}, success=${outcome.success}',
       );
 
-      // Update notification with results
+      // Update notification with results (foreground service always runs
+      // while folder sync is enabled, so the notification is always present).
       final settings = SettingsModel();
       await settings.loadSettings();
-      if (settings.showPersistentNotification) {
-        final next = getNextFolderSyncRunTime(
-          settings.folderSyncIntervalSeconds,
-        );
-        await updateCompanionNotification(
-          statusBody: buildCompanionNotificationBody(
-            connectionText: 'Next sync: ${formatNextFolderSync(next)}',
-            folderSyncOn: true,
-            bubbleOn: settings.showFloatingBubble,
-          ),
-        );
-      }
+      final next = getNextFolderSyncRunTime(
+        settings.folderSyncIntervalSeconds,
+      );
+      await updateCompanionNotification(
+        statusBody: buildCompanionNotificationBody(
+          connectionText: 'Next sync: ${formatNextFolderSync(next)}',
+          folderSyncOn: true,
+          bubbleOn: settings.showFloatingBubble,
+        ),
+      );
 
       // Note: Next alarm is automatically rescheduled by FolderSyncAlarmReceiver
       // before this task runs, so we don't need to reschedule here
@@ -219,6 +219,11 @@ Future<FolderScanOutcome> processScheduledFolders() async {
       debugPrint(
         '[FolderSync] Server URL not configured, skipping folder scan',
       );
+      return (success: true, uploaded: 0);
+    }
+
+    if (!await NetworkGate.canAutoUpload(wifiOnly: settings.uploadOnlyOnWifi)) {
+      debugPrint('[FolderSync] Paused: WiFi-only enabled and not on WiFi');
       return (success: true, uploaded: 0);
     }
 
@@ -425,23 +430,25 @@ Future<void> scheduleFolderScanTask() async {
       return;
     }
 
-    if (settings.showPersistentNotification) {
-      final granted = await NotificationService.instance
-          .requestNotificationPermission();
-      if (granted != false) {
-        debugPrint('[BackgroundTask] Starting foreground service...');
-        await startCompanionForegroundService(
-          folderSyncEnabled: true,
-          bubbleEnabled: settings.showFloatingBubble,
-          statusBody: buildCompanionNotificationBody(
-            folderSyncOn: true,
-            bubbleOn: settings.showFloatingBubble,
-          ),
-        );
-        debugPrint('[BackgroundTask] Foreground service started');
-      } else {
-        debugPrint('[BackgroundTask] WARNING: Notification permission not granted!');
-      }
+    // Foreground service is required whenever folder sync is enabled: Android
+    // requires a notification for dataSync services, and without it OEMs kill
+    // the process aggressively. The persistent-notification preference no
+    // longer gates this — it was silently disabling folder sync.
+    final granted = await NotificationService.instance
+        .requestNotificationPermission();
+    if (granted != false) {
+      debugPrint('[BackgroundTask] Starting foreground service...');
+      await startCompanionForegroundService(
+        folderSyncEnabled: true,
+        bubbleEnabled: settings.showFloatingBubble,
+        statusBody: buildCompanionNotificationBody(
+          folderSyncOn: true,
+          bubbleOn: settings.showFloatingBubble,
+        ),
+      );
+      debugPrint('[BackgroundTask] Foreground service started');
+    } else {
+      debugPrint('[BackgroundTask] WARNING: Notification permission not granted!');
     }
 
     final nextSync = getNextFolderSyncRunTime(intervalSeconds);

--- a/mobile-app/lib/src/services/network_gate.dart
+++ b/mobile-app/lib/src/services/network_gate.dart
@@ -1,0 +1,29 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
+
+/// Small helper around connectivity_plus used to gate automatic uploads
+/// (scheduled folder sync, offline-queue flush) when the user has turned on
+/// "Upload only on WiFi".
+///
+/// Ethernet is treated as equivalent to WiFi (unmetered, same user intent).
+/// Manual user actions should not consult this gate — if the user explicitly
+/// taps "Sync Now", the preference is intentionally bypassed.
+class NetworkGate {
+  static Future<bool> isOnWifiOrEthernet() async {
+    try {
+      final results = await Connectivity().checkConnectivity();
+      return results.contains(ConnectivityResult.wifi) ||
+          results.contains(ConnectivityResult.ethernet);
+    } catch (e) {
+      // Fail open: if we can't check, assume OK rather than blocking uploads forever.
+      debugPrint('[NetworkGate] Connectivity check failed, allowing upload: $e');
+      return true;
+    }
+  }
+
+  /// True if an automatic upload may proceed given the wifi-only preference.
+  static Future<bool> canAutoUpload({required bool wifiOnly}) async {
+    if (!wifiOnly) return true;
+    return await isOnWifiOrEthernet();
+  }
+}

--- a/mobile-app/lib/src/services/offline_queue.dart
+++ b/mobile-app/lib/src/services/offline_queue.dart
@@ -4,7 +4,9 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'backend_client.dart';
+import 'network_gate.dart';
 import 'notification_service.dart';
+import 'settings_model.dart';
 
 class OfflineQueueEntry {
   final String type; // 'url' or 'file'
@@ -92,6 +94,13 @@ class OfflineQueue {
   static Future<int> flush(BackendClient client) async {
     final entries = await _getEntries();
     if (entries.isEmpty) return 0;
+
+    final settings = SettingsModel();
+    await settings.loadSettings();
+    if (!await NetworkGate.canAutoUpload(wifiOnly: settings.uploadOnlyOnWifi)) {
+      debugPrint('[OfflineQueue] Paused: WiFi-only enabled and not on WiFi');
+      return 0;
+    }
 
     debugPrint('[OfflineQueue] Flushing ${entries.length} queued entries');
     int processed = 0;

--- a/mobile-app/lib/src/services/settings_model.dart
+++ b/mobile-app/lib/src/services/settings_model.dart
@@ -23,6 +23,7 @@ class SettingsModel extends ChangeNotifier {
   bool _deleteMediaAfterSync = false;
   bool _showPersistentNotification = true;
   bool _showFloatingBubble = false;
+  bool _uploadOnlyOnWifi = false;
   int _folderSyncIntervalSeconds = 900;
   bool _isAuthenticated = false;
   String? _username;
@@ -38,6 +39,7 @@ class SettingsModel extends ChangeNotifier {
   bool get deleteMediaAfterSync => _deleteMediaAfterSync;
   bool get showPersistentNotification => _showPersistentNotification;
   bool get showFloatingBubble => _showFloatingBubble;
+  bool get uploadOnlyOnWifi => _uploadOnlyOnWifi;
   int get folderSyncIntervalSeconds => _folderSyncIntervalSeconds;
   bool get isAuthenticated => _isAuthenticated;
   String? get username => _username;
@@ -55,6 +57,7 @@ class SettingsModel extends ChangeNotifier {
     _deleteMediaAfterSync = prefs.getBool('deleteMediaAfterSync') ?? false;
     _showPersistentNotification = prefs.getBool('showPersistentNotification') ?? true;
     _showFloatingBubble = prefs.getBool('showFloatingBubble') ?? false;
+    _uploadOnlyOnWifi = prefs.getBool('uploadOnlyOnWifi') ?? false;
     _folderSyncIntervalSeconds = prefs.getInt('folderSyncIntervalSeconds') ?? 900;
     _isAuthenticated = prefs.containsKey('auth_tokens');
     _username = prefs.getString('username');
@@ -92,6 +95,7 @@ class SettingsModel extends ChangeNotifier {
     bool? deleteMediaAfterSync,
     bool? showPersistentNotification,
     bool? showFloatingBubble,
+    bool? uploadOnlyOnWifi,
     int? folderSyncIntervalSeconds,
   }) async {
     final prefs = await SharedPreferences.getInstance();
@@ -140,6 +144,10 @@ class SettingsModel extends ChangeNotifier {
       _showFloatingBubble = showFloatingBubble;
       await prefs.setBool('showFloatingBubble', _showFloatingBubble);
     }
+    if (uploadOnlyOnWifi != null) {
+      _uploadOnlyOnWifi = uploadOnlyOnWifi;
+      await prefs.setBool('uploadOnlyOnWifi', _uploadOnlyOnWifi);
+    }
     if (folderSyncIntervalSeconds != null) {
       _folderSyncIntervalSeconds = folderSyncIntervalSeconds.clamp(900, 604800);
       await prefs.setInt('folderSyncIntervalSeconds', _folderSyncIntervalSeconds);
@@ -162,6 +170,7 @@ class SettingsModel extends ChangeNotifier {
     _deleteMediaAfterSync = false;
     _showPersistentNotification = true;
     _showFloatingBubble = false;
+    _uploadOnlyOnWifi = false;
     _folderSyncIntervalSeconds = 900;
     _isAuthenticated = false;
     _username = null;
@@ -194,6 +203,7 @@ class SettingsModel extends ChangeNotifier {
       'deleteMediaAfterSync': _deleteMediaAfterSync,
       'showPersistentNotification': _showPersistentNotification,
       'showFloatingBubble': _showFloatingBubble,
+      'uploadOnlyOnWifi': _uploadOnlyOnWifi,
       'folderSyncIntervalSeconds': _folderSyncIntervalSeconds,
       'scheduledFolders': folders.map((f) => f.toJson()).toList(),
     };
@@ -241,6 +251,10 @@ class SettingsModel extends ChangeNotifier {
       _showFloatingBubble = prefs['showFloatingBubble'] as bool? ?? _showFloatingBubble;
       await prefsStorage.setBool('showFloatingBubble', _showFloatingBubble);
     }
+    if (prefs.containsKey('uploadOnlyOnWifi')) {
+      _uploadOnlyOnWifi = prefs['uploadOnlyOnWifi'] as bool? ?? _uploadOnlyOnWifi;
+      await prefsStorage.setBool('uploadOnlyOnWifi', _uploadOnlyOnWifi);
+    }
     if (prefs.containsKey('folderSyncIntervalSeconds')) {
       final v = prefs['folderSyncIntervalSeconds'];
       if (v is int) {
@@ -276,6 +290,7 @@ class SettingsModel extends ChangeNotifier {
         'deleteMediaAfterSync': _deleteMediaAfterSync,
         'showPersistentNotification': _showPersistentNotification,
         'showFloatingBubble': _showFloatingBubble,
+        'uploadOnlyOnWifi': _uploadOnlyOnWifi,
         'folderSyncIntervalSeconds': _folderSyncIntervalSeconds,
         'scheduledFolders': folders.map((f) => f.toJson()).toList(),
       };
@@ -323,6 +338,7 @@ class SettingsModel extends ChangeNotifier {
       if (map.containsKey('deleteMediaAfterSync')) await prefs.setBool('deleteMediaAfterSync', map['deleteMediaAfterSync'] as bool? ?? false);
       if (map.containsKey('showPersistentNotification')) await prefs.setBool('showPersistentNotification', map['showPersistentNotification'] as bool? ?? true);
       if (map.containsKey('showFloatingBubble')) await prefs.setBool('showFloatingBubble', map['showFloatingBubble'] as bool? ?? false);
+      if (map.containsKey('uploadOnlyOnWifi')) await prefs.setBool('uploadOnlyOnWifi', map['uploadOnlyOnWifi'] as bool? ?? false);
       if (map.containsKey('folderSyncIntervalSeconds')) {
         final v = map['folderSyncIntervalSeconds'] as int? ?? 900;
         await prefs.setInt('folderSyncIntervalSeconds', v.clamp(900, 604800));

--- a/mobile-app/lib/src/widgets/settings/folder_settings_card.dart
+++ b/mobile-app/lib/src/widgets/settings/folder_settings_card.dart
@@ -10,12 +10,12 @@ class FolderSettingsCard extends StatelessWidget {
     required this.isSyncingFolders,
     required this.notifyOnFolderSync,
     required this.deleteMediaAfterSync,
-    required this.showPersistentNotification,
+    required this.uploadOnlyOnWifi,
     required this.folderSyncIntervalSeconds,
     required this.onSyncNow,
     required this.onNotifyOnFolderSyncChanged,
     required this.onDeleteMediaAfterSyncChanged,
-    required this.onShowPersistentNotificationChanged,
+    required this.onUploadOnlyOnWifiChanged,
     required this.onFolderSyncIntervalChanged,
     required this.onAutoSave,
   });
@@ -23,12 +23,12 @@ class FolderSettingsCard extends StatelessWidget {
   final bool isSyncingFolders;
   final bool notifyOnFolderSync;
   final bool deleteMediaAfterSync;
-  final bool showPersistentNotification;
+  final bool uploadOnlyOnWifi;
   final int folderSyncIntervalSeconds;
   final VoidCallback onSyncNow;
   final ValueChanged<bool> onNotifyOnFolderSyncChanged;
   final ValueChanged<bool> onDeleteMediaAfterSyncChanged;
-  final ValueChanged<bool> onShowPersistentNotificationChanged;
+  final ValueChanged<bool> onUploadOnlyOnWifiChanged;
   final ValueChanged<int> onFolderSyncIntervalChanged;
   final VoidCallback onAutoSave;
 
@@ -102,13 +102,13 @@ class FolderSettingsCard extends StatelessWidget {
           ),
         const SizedBox(height: 12),
         SwitchListTile(
-          title: const Text('Show persistent status notification'),
+          title: const Text('Upload only on WiFi'),
           subtitle: const Text(
-            'Keep a notification in the status bar when folder sync is on (connectivity status).',
+            'Pause scheduled folder sync and offline retries while on cellular data.',
           ),
-          value: showPersistentNotification,
+          value: uploadOnlyOnWifi,
           onChanged: (value) {
-            onShowPersistentNotificationChanged(value);
+            onUploadOnlyOnWifiChanged(value);
             onAutoSave();
           },
         ),

--- a/mobile-app/lib/src/widgets/settings/quick_actions_card.dart
+++ b/mobile-app/lib/src/widgets/settings/quick_actions_card.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../services/app_state.dart';
+import '../../services/backend_client.dart';
+import '../section_card.dart';
+
+/// Top-of-settings card giving one-tap access to actions that used to live
+/// buried in folder settings: reconnect to CCC and run folder sync now.
+class QuickActionsCard extends StatelessWidget {
+  const QuickActionsCard({
+    super.key,
+    required this.isSyncingFolders,
+    required this.onSyncNow,
+  });
+
+  final bool isSyncingFolders;
+  final VoidCallback onSyncNow;
+
+  @override
+  Widget build(BuildContext context) {
+    final appState = context.watch<AppState>();
+    final state = appState.sseConnectionState;
+    final (statusText, statusColor, statusIcon) = switch (state) {
+      SseConnectionState.connected => ('Connected', Colors.green, Icons.check_circle),
+      SseConnectionState.connecting => ('Connecting…', Colors.amber, Icons.sync),
+      SseConnectionState.disconnected => ('Disconnected', Colors.redAccent, Icons.error_outline),
+    };
+
+    return SectionCard(
+      title: 'Quick Actions',
+      children: [
+        Row(
+          children: [
+            Icon(statusIcon, color: statusColor, size: 18),
+            const SizedBox(width: 8),
+            Text(
+              statusText,
+              style: TextStyle(color: statusColor, fontWeight: FontWeight.w600),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: state == SseConnectionState.connecting
+                    ? null
+                    : () => appState.reconnect(),
+                icon: const Icon(Icons.refresh),
+                label: const Text('Reconnect'),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: ElevatedButton.icon(
+                onPressed: isSyncingFolders ? null : onSyncNow,
+                icon: isSyncingFolders
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.sync),
+                label: Text(isSyncingFolders ? 'Syncing…' : 'Sync Now'),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -45,6 +45,9 @@ dependencies:
   # Battery optimization (folder sync reliability)
   battery_optimization_helper: ^0.2.0
 
+  # Network connectivity detection (for "Upload on WiFi only" gating)
+  connectivity_plus: ^6.0.5
+
   # App restart (e.g. after settings restore)
   flutter_phoenix: ^1.1.0
 


### PR DESCRIPTION
## Summary

### 1. Chunked uploads for large files (`d581bd4`)
Backend gains `/api/jobs/upload/init`, `/chunk/{id}/{n}`, `/complete/{id}`, and `DELETE /upload/{id}`. Sessions live in Redis (24h TTL) with chunks on disk; the `/complete` endpoint reassembles and creates a standard FILE job. Mobile client auto-switches to chunked mode above 50 MB, splitting into 10 MB chunks with per-chunk retry. Solves silent failures behind Cloudflare's 100 MB per-request limit.

### 2. Mobile reliability + UX improvements (`f60d44e`)

**Folder sync reliability** — root cause of sync dying when the bubble was off: `showPersistentNotification` silently gated the foreground service in 6 places. Decoupled. Added `BootReceiver` so alarms survive reboot, and a 30s partial wake lock during WorkManager handoff.

**WiFi-only setting** — new toggle pauses scheduled folder sync and offline-queue flushes on cellular. Manual "Sync Now" still works.

**Settings cleanup** — new Quick Actions card at top of Settings with live connection status, one-tap Reconnect and Sync Now (previously buried in Folder Settings). Removed the now-dead "Show persistent notification" toggle.

**Crash investigation** — the app had no global error handlers, so every uncaught exception died silently. Installed `FlutterError.onError`, `PlatformDispatcher.onError`, and `runZonedGuarded`. Also fixed a real stream-subscription leak in `AppState._connectSse` that accumulated dead listeners on every reconnect.