### PR TITLE
feat(backend): reject job URLs that resolve to internal addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to Szurubooru Companion (CCC, browser extension, mobile app)
 ### CCC - Frontend
 
 ### CCC - Backend
+- `POST /api/jobs` now rejects URLs that resolve to loopback, link-local, cloud-metadata or private addresses, so a job that could never have been downloaded fails immediately with a clear message instead of queueing and failing minutes later. Hosts are resolved and the resulting addresses classified, so alternate encodings and public DNS names pointing at internal addresses are caught too.
+- Added `CCC_ALLOW_PRIVATE_NETWORK_URLS` (default `false`, requires restart) for setups where the backend genuinely can reach a LAN host. It permits RFC1918/ULA only; loopback, link-local and cloud metadata addresses stay blocked either way. This does not cover gallery-dl/yt-dlp subprocess downloads, which need container-level egress rules.
+- Direct media downloads now validate every resolved address at connect time, covering redirect hops and URLs produced by gallery-dl that the API never sees.
+- Job URL rejections now carry a machine-readable `error_code` (`unsupported_scheme`, `unsupported_url`, `blocked_address`, `dns_resolution_failed`) alongside the existing `detail` string, so clients can tell "cannot reach that" apart from "that is a feed URL".
 
 ### Mobile App
 

--- a/ccc/backend/.env.dev.example
+++ b/ccc/backend/.env.dev.example
@@ -41,6 +41,14 @@ WD14_USE_PROCESS_POOL=false
 WORKER_CONCURRENCY=1
 JOB_DATA_DIR=/data/jobs
 
+# --- Outbound URL guarding ---
+# Job URLs are resolved and checked before they are fetched. By default anything that
+# resolves into private space is refused. Set to true only if you submit URLs from a
+# self-hosted booru on your LAN (permits RFC1918 10/8, 172.16/12, 192.168/16 and IPv6 ULA).
+# Loopback, link-local and cloud metadata addresses stay blocked either way.
+# This does not apply to gallery-dl/yt-dlp subprocess downloads, which use their own HTTP stack.
+CCC_ALLOW_PRIVATE_NETWORK_URLS=false
+
 # --- Server ---
 # TODO: HOST and PORT are loaded in config but not used; Dockerfile CMD hardcodes --host/--port.
 # To utilize: run uvicorn from code (e.g. app/__main__.py) with settings.host/settings.port, or pass manually: uvicorn ... --host $HOST --port $PORT

--- a/ccc/backend/.env.example
+++ b/ccc/backend/.env.example
@@ -35,6 +35,14 @@ WD14_USE_PROCESS_POOL=false
 # so this lives in ENV rather than the dashboard. Set to match your CPU core count for max throughput.
 WORKER_CONCURRENCY=1
 
+# --- Outbound URL guarding ---
+# Job URLs are resolved and checked before they are fetched. By default anything that
+# resolves into private space is refused. Set to true only if you submit URLs from a
+# self-hosted booru on your LAN (permits RFC1918 10/8, 172.16/12, 192.168/16 and IPv6 ULA).
+# Loopback, link-local and cloud metadata addresses stay blocked either way.
+# This does not apply to gallery-dl/yt-dlp subprocess downloads, which use their own HTTP stack.
+CCC_ALLOW_PRIVATE_NETWORK_URLS=false
+
 # --- Server ---
 # TODO: HOST and PORT are loaded in config but not used; Dockerfile CMD hardcodes --host/--port.
 # To utilize: run uvicorn from code (e.g. app/__main__.py) with settings.host/settings.port, or pass manually: uvicorn ... --host $HOST --port $PORT

--- a/ccc/backend/app/api/job_url_validation.py
+++ b/ccc/backend/app/api/job_url_validation.py
@@ -1,54 +1,130 @@
 """
-Job URL validation: reject feed/home and bare-domain URLs that cannot be processed.
+Job URL validation: reject feed/home and bare-domain URLs that cannot be processed,
+and URLs whose host resolves to an address the backend must not fetch.
+
+Every rejection carries a machine-readable code so clients can react to the reason
+(e.g. fall back to a byte upload only when the address itself was blocked).
 """
 
 import re
+from dataclasses import dataclass
+from typing import Optional
 from urllib.parse import urlparse
 
 from app.sites import get_handler
+from app.utils.network import (
+    ERROR_BLOCKED_ADDRESS,
+    ERROR_DNS_RESOLUTION_FAILED,
+    check_host,
+)
+
+ERROR_UNSUPPORTED_SCHEME = "unsupported_scheme"
+ERROR_UNSUPPORTED_URL = "unsupported_url"
+
+_UNSUPPORTED_URL_MESSAGE = (
+    "URL is not allowed: use a direct link to a post or media, not a feed or site homepage."
+)
 
 
-def is_rejected_job_url(url: str) -> bool:
+@dataclass(frozen=True)
+class JobUrlRejection:
+    """Why a job URL was refused, in both human and machine readable form."""
+
+    error_code: str
+    message: str
+
+
+def check_job_url_shape(url: str) -> Optional[JobUrlRejection]:
     """
-    Return True if the URL must not be accepted as a job URL.
+    Reject URLs that cannot be processed regardless of where they point.
 
     Rejects:
+    - Non-http(s) or unparseable URLs.
     - Twitter/X feed URLs (x.com/home, twitter.com/home) which are not a specific post.
     - Reddit base or subreddit-only URLs (e.g. reddit.com, reddit.com/r/DIY); only post URLs with /comments/ are allowed.
     - Bare domain URLs for known sites (e.g. gelbooru.com, misskey.art) with no path or only "/".
     """
     if not url or not url.strip():
-        return True
+        return JobUrlRejection(ERROR_UNSUPPORTED_SCHEME, "URL is empty.")
     url = url.strip()
     try:
         parsed = urlparse(url)
-    except Exception:
-        return True
+        netloc = (parsed.netloc or "").lower().strip()
+    except ValueError:
+        return JobUrlRejection(ERROR_UNSUPPORTED_SCHEME, "URL could not be parsed.")
     scheme = (parsed.scheme or "").lower()
-    netloc = (parsed.netloc or "").lower().strip()
     if scheme not in ("http", "https") or not netloc:
-        return True
+        return JobUrlRejection(
+            ERROR_UNSUPPORTED_SCHEME, "URL is not allowed: only http and https URLs can be processed."
+        )
     path = (parsed.path or "").strip().rstrip("/") or "/"
     path_lower = path.lower()
 
     # Block Twitter/X home/feed URLs (not a specific post)
     if netloc in ("x.com", "www.x.com", "twitter.com", "www.twitter.com"):
         if path_lower == "/home" or path_lower.startswith("/home?"):
-            return True
+            return JobUrlRejection(ERROR_UNSUPPORTED_URL, _UNSUPPORTED_URL_MESSAGE)
 
     # Block Reddit base or subreddit-only; require a post (path must contain /comments/)
     if "reddit.com" in netloc:
         if path == "/" or path == "":
-            return True
+            return JobUrlRejection(ERROR_UNSUPPORTED_URL, _UNSUPPORTED_URL_MESSAGE)
         if re.match(r"^/r/[^/]+/?$", path, re.IGNORECASE):
-            return True
+            return JobUrlRejection(ERROR_UNSUPPORTED_URL, _UNSUPPORTED_URL_MESSAGE)
         if "/comments/" not in path_lower:
-            return True
+            return JobUrlRejection(ERROR_UNSUPPORTED_URL, _UNSUPPORTED_URL_MESSAGE)
 
     # For any known site handler, reject bare domain (no meaningful path)
     handler = get_handler(url)
     if not handler:
-        return False
+        return None
     if path == "/" or path == "":
-        return True
-    return False
+        return JobUrlRejection(ERROR_UNSUPPORTED_URL, _UNSUPPORTED_URL_MESSAGE)
+    return None
+
+
+async def check_job_url(url: str) -> Optional[JobUrlRejection]:
+    """
+    Full job URL check: shape first, then the addresses the host resolves to.
+
+    The host is taken from urlparse and classified by resolved address only; site
+    handlers match domains by substring and must never inform this decision.
+    """
+    shape_rejection = check_job_url_shape(url)
+    if shape_rejection is not None:
+        return shape_rejection
+
+    parsed = urlparse(url.strip())
+    try:
+        host = parsed.hostname or ""
+        port = parsed.port or 0
+    except ValueError:
+        return JobUrlRejection(ERROR_UNSUPPORTED_SCHEME, "URL could not be parsed.")
+
+    result = await check_host(host, port)
+    if result.allowed:
+        return None
+    return JobUrlRejection(
+        result.error_code or ERROR_BLOCKED_ADDRESS,
+        result.message or "URL host could not be verified.",
+    )
+
+
+def is_rejected_job_url(url: str) -> bool:
+    """
+    Boolean form of the shape check only, mirrored by the browser extension's
+    utils/job_url_validation.ts. Address checks live in check_job_url.
+    """
+    return check_job_url_shape(url) is not None
+
+
+__all__ = [
+    "ERROR_BLOCKED_ADDRESS",
+    "ERROR_DNS_RESOLUTION_FAILED",
+    "ERROR_UNSUPPORTED_SCHEME",
+    "ERROR_UNSUPPORTED_URL",
+    "JobUrlRejection",
+    "check_job_url",
+    "check_job_url_shape",
+    "is_rejected_job_url",
+]

--- a/ccc/backend/app/api/jobs.py
+++ b/ccc/backend/app/api/jobs.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import cast, func, select, String, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,7 +27,7 @@ from app.api.deps import get_current_user
 from app.services.config import load_global_config
 from app.sites import normalize_url
 
-from app.api.job_url_validation import is_rejected_job_url
+from app.api.job_url_validation import JobUrlRejection, check_job_url, check_job_url_shape
 
 router = APIRouter()
 settings = get_settings()
@@ -239,6 +240,14 @@ def _job_to_out(job: Job, dashboard_username: Optional[str] = None) -> JobOut:
     )
 
 
+def _rejection_response(rejection: JobUrlRejection) -> JSONResponse:
+    """400 body keeps "detail" a plain string for old clients and adds "error_code" for new ones."""
+    return JSONResponse(
+        status_code=400,
+        content={"detail": rejection.message, "error_code": rejection.error_code},
+    )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -252,12 +261,14 @@ async def create_job_url(
 ):
     """Create a job from a URL."""
     raw_url = (body.url or "").strip()
-    if is_rejected_job_url(raw_url):
-        raise HTTPException(
-            status_code=400,
-            detail="URL is not allowed: use a direct link to a post or media, not a feed or site homepage.",
-        )
-    url = normalize_url(raw_url)
+    rejection = check_job_url_shape(raw_url)
+    # Handlers may rewrite the netloc, so the address check runs on the URL we persist.
+    url = raw_url if rejection else normalize_url(raw_url)
+    if rejection is None:
+        rejection = await check_job_url(url)
+    if rejection is not None:
+        return _rejection_response(rejection)
+
     job = Job(
         job_type=JobType.URL,
         url=url,

--- a/ccc/backend/app/config.py
+++ b/ccc/backend/app/config.py
@@ -39,6 +39,11 @@ class Settings:
     # disable when worker_concurrency > 1 so all workers share the thread pool concurrently)
     wd14_use_process_pool: bool = os.getenv("WD14_USE_PROCESS_POOL", "false").lower() == "true"
 
+    # --- Outbound URL guarding ---
+    # Permit job URLs that resolve into RFC1918/ULA space (self-hosted boorus on the LAN).
+    # Loopback, link-local and cloud metadata addresses stay blocked either way.
+    allow_private_network_urls: bool = os.getenv("CCC_ALLOW_PRIVATE_NETWORK_URLS", "false").lower() == "true"
+
     # --- Worker & Paths ---
     # worker_concurrency requires a restart (workers are spawned at startup), so it lives in ENV.
     worker_concurrency: int = int(os.getenv("WORKER_CONCURRENCY", "1"))

--- a/ccc/backend/app/services/downloader.py
+++ b/ccc/backend/app/services/downloader.py
@@ -8,15 +8,20 @@ import asyncio
 import json
 import logging
 import os
+import socket
 import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 from urllib.parse import urlparse, parse_qs
+
+import aiohttp
+from aiohttp.abc import AbstractResolver
 
 from app.config import get_settings
 from app.sites.registry import get_handler
+from app.utils.network import BlockedHostError, filter_allowed_hosts
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -193,6 +198,62 @@ async def download_url(
     return result
 
 
+def _drop_blocked_results(host: str, infos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Keep only the resolution results that point at a permitted address."""
+    allowed_hosts, reasons = filter_allowed_hosts([info["host"] for info in infos])
+    surviving = set(allowed_hosts)
+    allowed = [info for info in infos if info["host"] in surviving]
+    if not allowed:
+        raise BlockedHostError(
+            f"host '{host}' resolves only to blocked addresses ({'; '.join(reasons)})"
+        )
+    return allowed
+
+
+class _GuardedResolver(AbstractResolver):
+    """
+    DNS resolver that drops denied addresses before aiohttp can connect to them.
+
+    Deliberately scoped to the direct-download session only: it must not sit in front
+    of Szurubooru traffic, which is expected to reach docker-internal addresses.
+    """
+
+    def __init__(self) -> None:
+        self._delegate = aiohttp.DefaultResolver()
+
+    async def resolve(self, host: str, port: int = 0, family: int = socket.AF_INET) -> List[Dict[str, Any]]:
+        return _drop_blocked_results(host, await self._delegate.resolve(host, port, family))
+
+    async def close(self) -> None:
+        await self._delegate.close()
+
+
+# _GuardedConnector overrides a private aiohttp method. A changed signature raises and
+# fails closed, but a rename would leave the override silently uncalled, so refuse to
+# start rather than run with a guard that quietly stopped filtering.
+if not hasattr(aiohttp.TCPConnector, "_resolve_host"):
+    raise RuntimeError(
+        "aiohttp.TCPConnector._resolve_host is missing; the download address guard "
+        "would no longer filter. Pin aiohttp or update _GuardedConnector."
+    )
+
+
+class _GuardedConnector(aiohttp.TCPConnector):
+    """
+    Connector that re-checks every resolved address, literal hosts included.
+
+    aiohttp answers IP-literal hosts (and DNS cache hits) without consulting the
+    resolver, so the resolver alone would let http://127.0.0.1/ through. Filtering at
+    the connector covers those paths, re-runs for every redirect hop, and guarantees
+    the address that was validated is the address connected to.
+    """
+
+    async def _resolve_host(
+        self, host: str, port: int, traces: Optional[Sequence[Any]] = None
+    ) -> List[Dict[str, Any]]:
+        return _drop_blocked_results(host, await super()._resolve_host(host, port, traces))
+
+
 async def download_direct_media_url(url: str, dest_dir: str, filename: Optional[str] = None) -> DownloadResult:
     """
     Download a direct media URL (e.g., pbs.twimg.com/media/xxx.jpg) directly.
@@ -208,15 +269,14 @@ async def download_direct_media_url(url: str, dest_dir: str, filename: Optional[
     Returns:
         DownloadResult with the downloaded file path.
     """
-    import aiohttp
-
     os.makedirs(dest_dir, exist_ok=True)
     result = DownloadResult(source_url=url, used_tool="direct")
 
     headers = {"User-Agent": DEFAULT_DOWNLOAD_USER_AGENT}
 
     try:
-        async with aiohttp.ClientSession() as session:
+        connector = _GuardedConnector(resolver=_GuardedResolver())
+        async with aiohttp.ClientSession(connector=connector) as session:
             async with session.get(
                 url, headers=headers, timeout=aiohttp.ClientTimeout(total=60)
             ) as resp:
@@ -281,6 +341,15 @@ async def download_direct_media_url(url: str, dest_dir: str, filename: Optional[
     except asyncio.TimeoutError:
         result.error = "Direct download timed out"
         logger.error("Direct download timed out for %s", url)
+    except aiohttp.ClientConnectorError as exc:
+        # aiohttp wraps resolver errors, so unwrap ours for a message that explains itself.
+        blocked = getattr(exc, "os_error", None)
+        if isinstance(blocked, BlockedHostError):
+            result.error = f"Refused to download from a blocked address: {blocked.message}"
+            logger.warning("Direct download blocked for %s: %s", url, blocked.message)
+        else:
+            result.error = str(exc)
+            logger.exception("Direct download failed for %s", url)
     except Exception as exc:
         result.error = str(exc)
         logger.exception("Direct download failed for %s", url)

--- a/ccc/backend/app/utils/network.py
+++ b/ccc/backend/app/utils/network.py
@@ -1,0 +1,231 @@
+"""
+Outbound address guarding for user-supplied URLs.
+
+Hosts are resolved and the resulting IP objects are classified; hostname strings
+are never pattern-matched. Resolving first makes alternate encodings (decimal,
+octal, hex, IPv6 shorthand, trailing dot) and public DNS names that point at
+private space (localtest.me, *.nip.io) collapse into real addresses.
+"""
+
+import asyncio
+import errno
+import ipaddress
+import socket
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple, Union
+
+from app.config import get_settings
+
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+IPNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
+
+DNS_TIMEOUT_SECONDS = 3.0
+
+# Machine-readable outcomes, surfaced to API clients as "error_code".
+ERROR_BLOCKED_ADDRESS = "blocked_address"
+ERROR_DNS_RESOLUTION_FAILED = "dns_resolution_failed"
+
+# How an admin lifts the private-network restriction (loopback etc. stay blocked).
+PRIVATE_NETWORK_HINT = (
+    "Private network URLs are disabled; set CCC_ALLOW_PRIVATE_NETWORK_URLS=true to permit "
+    "RFC1918/ULA addresses (loopback, link-local and metadata addresses stay blocked)."
+)
+
+# Denied regardless of the CCC_ALLOW_PRIVATE_NETWORK_URLS toggle.
+_ALWAYS_BLOCKED: Tuple[Tuple[IPNetwork, str], ...] = (
+    (ipaddress.ip_network("0.0.0.0/8"), "unspecified address"),
+    (ipaddress.ip_network("127.0.0.0/8"), "loopback address"),
+    (ipaddress.ip_network("169.254.0.0/16"), "link-local address"),
+    (ipaddress.ip_network("192.0.0.0/24"), "IETF protocol assignment"),
+    (ipaddress.ip_network("198.18.0.0/15"), "benchmarking address"),
+    (ipaddress.ip_network("224.0.0.0/4"), "multicast address"),
+    (ipaddress.ip_network("255.255.255.255/32"), "broadcast address"),
+    (ipaddress.ip_network("240.0.0.0/4"), "reserved address"),
+    # CGNAT, kept out of the toggle so Alibaba's 100.100.100.200 metadata endpoint
+    # stays blocked without a second carve-out.
+    (ipaddress.ip_network("100.64.0.0/10"), "carrier-grade NAT address"),
+    (ipaddress.ip_network("::/128"), "unspecified address"),
+    (ipaddress.ip_network("::1/128"), "loopback address"),
+    (ipaddress.ip_network("fe80::/10"), "link-local address"),
+    (ipaddress.ip_network("ff00::/8"), "multicast address"),
+    # EC2 IMDS lives inside the ULA range the toggle would otherwise permit.
+    (ipaddress.ip_network("fd00:ec2::254/128"), "cloud metadata address"),
+)
+
+# Denied by default, permitted when CCC_ALLOW_PRIVATE_NETWORK_URLS is enabled.
+_PRIVATE_BLOCKED: Tuple[Tuple[IPNetwork, str], ...] = (
+    (ipaddress.ip_network("10.0.0.0/8"), "private network address"),
+    (ipaddress.ip_network("172.16.0.0/12"), "private network address"),
+    (ipaddress.ip_network("192.168.0.0/16"), "private network address"),
+    (ipaddress.ip_network("fc00::/7"), "unique local address"),
+)
+
+_SIX_TO_FOUR = ipaddress.ip_network("2002::/16")
+_NAT64 = ipaddress.ip_network("64:ff9b::/96")
+
+
+class BlockedHostError(OSError):
+    """
+    Raised when a host cannot be resolved to at least one permitted address.
+
+    Subclasses OSError so aiohttp preserves it as ClientConnectorError.os_error.
+    """
+
+    def __init__(self, message: str, error_code: str = ERROR_BLOCKED_ADDRESS) -> None:
+        super().__init__(errno.EACCES, message)
+        self.message = message
+        self.error_code = error_code
+
+
+@dataclass(frozen=True)
+class HostCheck:
+    """Outcome of resolving and classifying every address behind a host."""
+
+    allowed: bool
+    error_code: Optional[str] = None
+    message: Optional[str] = None
+
+
+def _embedded_ipv4(address: IPAddress) -> Optional[ipaddress.IPv4Address]:
+    """Extract the IPv4 address wrapped by v4-mapped, 6to4 or NAT64 forms."""
+    if not isinstance(address, ipaddress.IPv6Address):
+        return None
+    if address.ipv4_mapped is not None:
+        return address.ipv4_mapped
+    packed = address.packed
+    if address in _SIX_TO_FOUR:
+        return ipaddress.IPv4Address(packed[2:6])
+    if address in _NAT64:
+        return ipaddress.IPv4Address(packed[12:16])
+    return None
+
+
+def classify_address(address: IPAddress) -> Optional[str]:
+    """Return a human-readable reason the address is denied, or None if permitted."""
+    embedded = _embedded_ipv4(address)
+    if embedded is not None:
+        embedded_reason = classify_address(embedded)
+        if embedded_reason is not None:
+            return f"{embedded_reason} embedded in an IPv6 address"
+
+    for network, reason in _ALWAYS_BLOCKED:
+        if address.version == network.version and address in network:
+            return reason
+
+    if get_settings().allow_private_network_urls:
+        return None
+
+    for network, reason in _PRIVATE_BLOCKED:
+        if address.version == network.version and address in network:
+            return reason
+    return None
+
+
+def _toggle_would_permit(address: IPAddress) -> bool:
+    """True when enabling the private-network toggle would actually unblock this address."""
+    embedded = _embedded_ipv4(address)
+    if embedded is not None and _toggle_would_permit(embedded):
+        return True
+
+    for network, _ in _ALWAYS_BLOCKED:
+        if address.version == network.version and address in network:
+            return False
+
+    return any(
+        address.version == network.version and address in network
+        for network, _ in _PRIVATE_BLOCKED
+    )
+
+
+def any_toggle_would_permit(hosts: Sequence[str]) -> bool:
+    """True when the toggle would unblock at least one of these addresses."""
+    for host in hosts:
+        try:
+            address = ipaddress.ip_address(host.split("%")[0])
+        except ValueError:
+            continue
+        if _toggle_would_permit(address):
+            return True
+    return False
+
+
+def filter_allowed_hosts(hosts: Sequence[str]) -> Tuple[List[str], List[str]]:
+    """
+    Split resolved address literals into the permitted ones and block reasons.
+
+    Returns the surviving literals unchanged so callers can match them back onto
+    their own resolution results.
+    """
+    allowed: List[str] = []
+    reasons: List[str] = []
+    for host in hosts:
+        literal = host.split("%")[0]
+        try:
+            address = ipaddress.ip_address(literal)
+        except ValueError:
+            reasons.append(f"{host}: not a valid IP address")
+            continue
+        reason = classify_address(address)
+        if reason is None:
+            allowed.append(host)
+        else:
+            reasons.append(f"{literal}: {reason}")
+    return allowed, reasons
+
+
+async def resolve_host(host: str, port: int = 0) -> List[str]:
+    """
+    Resolve a host to address literals without blocking the event loop.
+
+    Raises BlockedHostError with the DNS error code on failure or timeout.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await asyncio.wait_for(
+            loop.getaddrinfo(host, port or None, type=socket.SOCK_STREAM),
+            timeout=DNS_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        raise BlockedHostError(
+            f"DNS resolution for '{host}' timed out after {DNS_TIMEOUT_SECONDS:g}s.",
+            ERROR_DNS_RESOLUTION_FAILED,
+        ) from None
+    except OSError as exc:
+        raise BlockedHostError(
+            f"Could not resolve host '{host}': {exc}.",
+            ERROR_DNS_RESOLUTION_FAILED,
+        ) from exc
+
+    literals = [str(info[4][0]) for info in infos]
+    if not literals:
+        raise BlockedHostError(
+            f"Could not resolve host '{host}': no addresses returned.",
+            ERROR_DNS_RESOLUTION_FAILED,
+        )
+    return literals
+
+
+async def check_host(host: str, port: int = 0) -> HostCheck:
+    """
+    Resolve a host and reject it if ANY returned address is denied.
+
+    Rejecting on any address (rather than the first) stops a resolver that mixes a
+    public address in with a private one from slipping through.
+    """
+    if not host:
+        return HostCheck(False, ERROR_BLOCKED_ADDRESS, "URL has no host to resolve.")
+
+    try:
+        literals = await resolve_host(host, port)
+    except BlockedHostError as exc:
+        return HostCheck(False, exc.error_code, exc.message)
+
+    _, reasons = filter_allowed_hosts(literals)
+    if reasons:
+        message = f"URL host '{host}' resolves to a blocked address ({'; '.join(reasons)})."
+        # Only point at the toggle when it would actually unblock this address;
+        # suggesting it for loopback or metadata addresses just misleads the admin.
+        if not get_settings().allow_private_network_urls and any_toggle_would_permit(literals):
+            message = f"{message} {PRIVATE_NETWORK_HINT}"
+        return HostCheck(False, ERROR_BLOCKED_ADDRESS, message)
+    return HostCheck(True)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,22 @@ If the onboarding wizard doesn't appear or you need to reconfigure after skippin
 - **Production:** [ccc/backend/.env.example](../ccc/backend/.env.example)
 - **Development:** [ccc/backend/.env.dev.example](../ccc/backend/.env.dev.example)
 
+## Outbound URL restrictions
+
+Job URLs submitted to `POST /api/jobs` are resolved before they are accepted, and the resolved addresses are checked against a deny list. Anything that lands on loopback, link-local (including `169.254.169.254`), unspecified, multicast, reserved, carrier-grade NAT (including `100.100.100.200`) or cloud metadata addresses is refused, and so is anything in private space by default. The check runs on the resolved address, not on the hostname text, so alternate encodings and public DNS names that point inward are covered. The same check is enforced again inside the connector used for direct media downloads, so every redirect hop is re-resolved and re-checked.
+
+Rejections return HTTP 400 with a human-readable `detail` string plus an `error_code` field: `unsupported_scheme`, `unsupported_url` (feed or homepage URL), `blocked_address`, or `dns_resolution_failed`.
+
+If you host a booru on your own LAN and want to submit URLs pointing at it, set:
+
+```env
+CCC_ALLOW_PRIVATE_NETWORK_URLS=true
+```
+
+This permits only RFC1918 ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) and IPv6 unique local addresses (`fc00::/7`). Loopback, link-local and cloud metadata addresses remain blocked even when it is enabled. The variable requires a restart to take effect.
+
+> **Scope:** this guard covers URLs the backend fetches itself. It does **not** cover downloads performed by the gallery-dl and yt-dlp subprocesses, which use their own HTTP stack, DNS and redirect handling and cannot be guarded in-process. If restricting where those subprocesses can connect matters to you, enforce it at the container or network level (egress firewall rules, a dedicated Docker network).
+
 ## Gallery-dl and tag extraction
 
 Gallery-dl is configured entirely from code; no config file is used. Per-user site credentials (Twitter, Sankaku, Rule34, etc.) are stored encrypted in the database and passed to gallery-dl via `-o` options at run time. Handlers (explicit and no-auth) supply tag options (e.g. `tags=true`, `tags=extended`) so gallery-dl returns categorized tags for Szurubooru. No-auth sites that support tags are listed in `site_registry.NO_AUTH_TAG_OPTIONS`.

--- a/unraid/szurubooru-companion.xml
+++ b/unraid/szurubooru-companion.xml
@@ -59,6 +59,11 @@
   <Config Name="Worker Concurrency" Target="WORKER_CONCURRENCY" Default="1" Mode="" Description="Number of background job workers to spawn (requires restart). Set higher to process multiple jobs in parallel. Disable WD14_USE_PROCESS_POOL when using more than 1 worker." Type="Variable" Display="always" Required="false" Mask="false">1</Config>
 
   <!-- ══════════════════════════════════════════════════════════════════ -->
+  <!-- Outbound URL Guarding                                            -->
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <Config Name="Allow Private Network URLs" Target="CCC_ALLOW_PRIVATE_NETWORK_URLS" Default="false" Mode="" Description="Allow job URLs that resolve into private space (RFC1918 10/8, 172.16/12, 192.168/16 and IPv6 ULA). Enable only if you submit URLs from a self-hosted booru on your LAN. Loopback, link-local and cloud metadata addresses stay blocked either way. Does not apply to gallery-dl/yt-dlp subprocess downloads." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
+
+  <!-- ══════════════════════════════════════════════════════════════════ -->
   <!-- Server Settings                                                  -->
   <!-- ══════════════════════════════════════════════════════════════════ -->
   <Config Name="Log Level" Target="LOG_LEVEL" Default="INFO" Mode="" Description="Logging level (DEBUG, INFO, WARNING, ERROR)" Type="Variable" Display="advanced" Required="false" Mask="false">INFO</Config>


### PR DESCRIPTION
Companion to #40. Independent of it — merge in either order.

## Problem

`POST /api/jobs` accepted any URL and the worker later fetched it, with no check that it pointed anywhere sane. Two consequences:

- **Correctness/UX:** a URL the backend could never download queued, burned retries, and failed minutes later as a generic `Failed to process <filename>`.
- **Security:** an authenticated user could aim the backend at loopback, LAN hosts, or cloud metadata endpoints. Graded P1 rather than P0 — it needs an account, and the read-back channel is weak — but yt-dlp's stderr reaches `job.error_message`, which is a usable port-existence oracle.

## Approach

**Resolve the host and classify the resulting addresses. Never pattern-match the hostname string.** Resolution is what makes `2130706433`, `0177.0.0.1`, `::ffff:127.0.0.1`, trailing dots, and public DNS names pointing at private space (`localtest.me`, `*.nip.io`) all collapse into an address that can actually be judged. A host is refused if *any* resolved address is blocked, so a resolver mixing a public address in with a private one does not slip through.

`CCC_ALLOW_PRIVATE_NETWORK_URLS` (default `false`) relaxes **RFC1918/ULA only**. Loopback, link-local, CGNAT and cloud metadata stay blocked in both states — loopback from inside the container is the app itself, and no NAS lives at `169.254.0.0/16`. `fd00:ec2::254` sits inside the ULA range the toggle permits, so it carries an explicit always-deny.

### Two layers, because the URL that gets fetched is not always the URL that was submitted

| Layer | Covers |
| --- | --- |
| `POST /api/jobs` | The submitted URL, which is what gets handed to the gallery-dl/yt-dlp subprocesses. For those, this check is the only in-process control that can ever exist. |
| Connector on the direct-download session | The media URLs gallery-dl emits at worker time, which the API never sees — plus every redirect hop and IP-literal hosts. |

The connector guard is deliberately **not** shared with the Szurubooru client: that talks to `http://szurubooru:8080` and other docker-internal addresses, and guarding it would break every containerized install. There is intentionally no common "safe HTTP client" helper for both to import.

### What this does not cover

The gallery-dl and yt-dlp subprocesses have their own HTTP stack, DNS and redirect handling and cannot be constrained in-process. The API check prevents a blocked URL from ever reaching them, but a permitted URL that redirects internally *inside* those tools is not stopped. `docs/configuration.md` says so plainly and points at container egress policy; this is not claimed as covered.

## Verification

No test infrastructure exists in this repo and none was added; correctness was demonstrated by driving the real code. Independent verification returned CONFIRMED, having written its own probes rather than reusing the implementer's:

- **Real sockets.** A live server on `127.0.0.1` is refused with no file written. A permitted LAN host that `302`s to `127.0.0.1` is refused on the second hop. Two sequential requests to the same blocked host are both refused, so a DNS-cache hit cannot bypass.
- **The literal-host trap.** aiohttp's `TCPConnector` short-circuits IP literals before consulting a custom resolver — a resolver-only guard lets `http://127.0.0.1/` straight through, which the first implementation attempt did empirically. The connector-level override was added for exactly this and was confirmed firing via a live stack frame.
- **Toggle matrix** across ~20 ranges in both states, including boundaries (`172.15/172.32`) and IPv6 unwrapping for v4-mapped, 6to4 and NAT64.
- **Error codes** are distinct and reachable; `https://x.com/home` yields `unsupported_url`, not `blocked_address`. That distinction is load-bearing for #40, which byte-uploads on the latter.
- **`szurubooru.py` is untouched**, confirmed by diff, with no global connector/resolver/monkeypatching anywhere.

Platform note: on Windows the resolver rejects decimal/short-form literals outright, so they surface as `dns_resolution_failed` rather than `blocked_address`. On Linux (the container target) they resolve and are correctly classified. Both reject; only the code differs.

## Compatibility

The 400 body keeps `detail` as a plain string and *adds* `error_code`, so existing clients are unaffected. The toggle requires a restart, like every other env var here — `Settings` field defaults evaluate at import. Documented as such.

## Known limitations

- The module-level `hasattr(aiohttp.TCPConnector, "_resolve_host")` assertion turns a rename into a loud startup failure rather than a silent unguarded connector, but it cannot catch every refactor shape — e.g. aiohttp hoisting its IP-literal short-circuit up a level. Re-run the literal probe on any aiohttp bump. A connect-time peer-address post-condition would be strictly stronger.
- `api/swiper.py:309` has the same unguarded session pattern in an API handler. Pre-existing and domain-allowlisted, so deliberately left alone here, but it is the same class of surface and worth its own look.
